### PR TITLE
:alembic: make Validate() methods abstract on commands and queries to negate the wasted base.Validate() calls and promote thought of what validation is required to perform the command/query

### DIFF
--- a/src/Codeo.CQRS.Tests/Commands/CreatePerson.cs
+++ b/src/Codeo.CQRS.Tests/Commands/CreatePerson.cs
@@ -30,5 +30,9 @@ namespace Codeo.CQRS.Tests.Commands
             Name = name;
             Enabled = enabled;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Commands/CreatePersonNoResult.cs
+++ b/src/Codeo.CQRS.Tests/Commands/CreatePersonNoResult.cs
@@ -28,5 +28,9 @@ namespace Codeo.CQRS.Tests.Commands
             Name = name;
             Enabled = enabled;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Commands/CreatePersonWithSideEffect.cs
+++ b/src/Codeo.CQRS.Tests/Commands/CreatePersonWithSideEffect.cs
@@ -20,5 +20,9 @@ namespace Codeo.CQRS.Tests.Commands
             IdToUpdate = idToUpdate;
             NewName = newName;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Commands/UpdatePersonName.cs
+++ b/src/Codeo.CQRS.Tests/Commands/UpdatePersonName.cs
@@ -15,6 +15,10 @@ namespace Codeo.CQRS.Tests.Commands
         {
             Id = id;
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     // cache should be ignored
@@ -34,6 +38,10 @@ namespace Codeo.CQRS.Tests.Commands
         )
         {
             Id = id;
+        }
+
+        public override void Validate()
+        {
         }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/AddPersonToDepartment.cs
+++ b/src/Codeo.CQRS.Tests/Queries/AddPersonToDepartment.cs
@@ -21,5 +21,9 @@ namespace Codeo.CQRS.Tests.Queries
             PersonId = personId;
             DepartmentId = departmentId;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/CreateDepartment.cs
+++ b/src/Codeo.CQRS.Tests/Queries/CreateDepartment.cs
@@ -18,6 +18,10 @@ namespace Codeo.CQRS.Tests.Queries
         {
             Name = name;
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     public class CreateTagForDepartment : InsertCommand<int>
@@ -41,6 +45,10 @@ namespace Codeo.CQRS.Tests.Queries
             DepartmentId = departmentId;
             Tag = tag;
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     public class FindTagsById : SelectQuery<IEnumerable<DepartmentTag>>
@@ -58,6 +66,10 @@ namespace Codeo.CQRS.Tests.Queries
             )
         {
             Ids = ids;
+        }
+
+        public override void Validate()
+        {
         }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/DeletePerson.cs
+++ b/src/Codeo.CQRS.Tests/Queries/DeletePerson.cs
@@ -9,5 +9,9 @@ namespace Codeo.CQRS.Tests.Queries
             )
         {
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/DeletePersonWithResult.cs
+++ b/src/Codeo.CQRS.Tests/Queries/DeletePersonWithResult.cs
@@ -11,6 +11,10 @@ namespace Codeo.CQRS.Tests.Queries
             )
         {
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     public class DeletePersonNoResultWithSideEffects : DeleteCommand
@@ -27,6 +31,10 @@ namespace Codeo.CQRS.Tests.Queries
             )
         {
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     public class DeletePersonWithArbResult : DeleteCommand<Person>
@@ -37,6 +45,10 @@ namespace Codeo.CQRS.Tests.Queries
                 select * from people where id = @otherId;",
                 new { id, otherId }
             )
+        {
+        }
+
+        public override void Validate()
         {
         }
     }

--- a/src/Codeo.CQRS.Tests/Queries/FindAllPeople.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindAllPeople.cs
@@ -9,5 +9,8 @@ namespace Codeo.CQRS.Tests.Queries
         {
         }
 
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindAllPeopleAndDepartments.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindAllPeopleAndDepartments.cs
@@ -18,5 +18,9 @@ namespace Codeo.CQRS.Tests.Queries
                     };
                 });
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindCarlSaganAlike.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindCarlSaganAlike.cs
@@ -7,11 +7,19 @@ namespace Codeo.CQRS.Tests.Queries
         public FindCarlSaganAlike() : base("select * from people where name = 'Carl Sagan';")
         {
         }
+
+        public override void Validate()
+        {
+        }
     }
 
     public class FindCarlSaganAlikes : SelectQuery<IEnumerable<PersonLike>>
     {
         public FindCarlSaganAlikes() : base("select * from people where name = 'Carl Sagan';")
+        {
+        }
+
+        public override void Validate()
         {
         }
     }

--- a/src/Codeo.CQRS.Tests/Queries/FindDepartmentsById.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindDepartmentsById.cs
@@ -16,5 +16,9 @@ namespace Codeo.CQRS.Tests.Queries
         {
             DepartmentIds = departmentIds;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPeopleByIds.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPeopleByIds.cs
@@ -21,6 +21,10 @@ namespace Codeo.CQRS.Tests.Queries
             );
         }
 
+        public override void Validate()
+        {
+        }
+
         public string GenerateCacheKeyForTesting()
         {
             return GenerateCacheKey();

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonById.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonById.cs
@@ -25,5 +25,9 @@ namespace Codeo.CQRS.Tests.Queries
                 "select * from people where id = @id;", new { Id }
             );
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonByIdShortLived.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonByIdShortLived.cs
@@ -24,5 +24,9 @@ namespace Codeo.CQRS.Tests.Queries
                 "select * from people where id = @id;", new { Id }
             );
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonByIdUncached.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonByIdUncached.cs
@@ -17,5 +17,9 @@ namespace Codeo.CQRS.Tests.Queries
                 "select * from people where id = @id;", new { Id }
             );
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonByIdWithInvalidCacheProp.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonByIdWithInvalidCacheProp.cs
@@ -12,5 +12,9 @@ namespace Codeo.CQRS.Tests.Queries
             )
         {
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonByIdWithPrivateCacheProp.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonByIdWithPrivateCacheProp.cs
@@ -15,5 +15,9 @@ namespace Codeo.CQRS.Tests.Queries
         {
             Id = id;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonByName.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonByName.cs
@@ -11,5 +11,9 @@ namespace Codeo.CQRS.Tests.Queries
         {
             Name = name;
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonWithDepartments.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonWithDepartments.cs
@@ -31,5 +31,9 @@ namespace Codeo.CQRS.Tests.Queries
                 collectionFinder: p => p.Departments as List<Department>
             ).FirstOrDefault();
         }
+
+        public override void Validate()
+        {
+        }
     }
 }

--- a/src/Codeo.CQRS.Tests/Queries/FindPersonWithDepartmentsAndTags.cs
+++ b/src/Codeo.CQRS.Tests/Queries/FindPersonWithDepartmentsAndTags.cs
@@ -52,6 +52,10 @@ namespace Codeo.CQRS.Tests.Queries
             Result = results.FirstOrDefault();
         }
 
+        public override void Validate()
+        {
+        }
+
         private DepartmentWithTags AddDepartmentFor(
             Department department, 
             IList<DepartmentWithTags> departments)

--- a/src/Codeo.CQRS.Tests/TestCommandExecution.cs
+++ b/src/Codeo.CQRS.Tests/TestCommandExecution.cs
@@ -158,6 +158,10 @@ namespace Codeo.CQRS.Tests
             {
                 Result = Execute(Operation.Insert, "select sleep(2);", null, 1, _customHandler);
             }
+
+            public override void Validate()
+            {
+            }
         }
 
 
@@ -169,6 +173,10 @@ namespace Codeo.CQRS.Tests
         public class TestCommand : Command
         {
             public override void Execute()
+            {
+            }
+
+            public override void Validate()
             {
             }
         }

--- a/src/Codeo.CQRS.Tests/TestFluently.cs
+++ b/src/Codeo.CQRS.Tests/TestFluently.cs
@@ -183,6 +183,10 @@ namespace Codeo.CQRS.Tests
                     new { Id }
                 );
             }
+
+            public override void Validate()
+            {
+            }
         }
 
         public class CreateCaseTestingEntity : Command<int>
@@ -205,6 +209,10 @@ namespace Codeo.CQRS.Tests
                 values (@TitleCase, @SnakeCase);
                 select LAST_INSERT_ID();
 ", new { TitleCase, SnakeCase });
+            }
+
+            public override void Validate()
+            {
             }
         }
 
@@ -232,6 +240,10 @@ namespace Codeo.CQRS.Tests
     public class GenericSelectQuery<T> : SelectQuery<T>
     {
         public GenericSelectQuery(string sql) : base(sql)
+        {
+        }
+
+        public override void Validate()
         {
         }
     }

--- a/src/Codeo.CQRS.Tests/TestQueryExecution.cs
+++ b/src/Codeo.CQRS.Tests/TestQueryExecution.cs
@@ -388,6 +388,10 @@ namespace Codeo.CQRS.Tests
                 )
                 {
                 }
+
+                public override void Validate()
+                {
+                }
             }
         }
 

--- a/src/Codeo.CQRS/Command.cs
+++ b/src/Codeo.CQRS/Command.cs
@@ -34,10 +34,7 @@ namespace Codeo.CQRS
         /// <summary>
         /// Validates this instance.
         /// </summary>
-        public virtual void Validate()
-        {
-            // not required to implement
-        }
+        public abstract void Validate();
 
         /// <summary>
         /// Ensures that a transaction scope is available

--- a/src/Codeo.CQRS/Query.cs
+++ b/src/Codeo.CQRS/Query.cs
@@ -17,10 +17,7 @@ namespace Codeo.CQRS
         /// <summary>
         /// Validates this instance.
         /// </summary>
-        public virtual void Validate()
-        {
-            // not required to override this
-        }
+        public abstract void Validate();
 
         public void ValidateTransactionScope()
         {


### PR DESCRIPTION
Proposed change: Validate methods on the base abstract Command and Query classes to be made abstract instead of virtual

Consumer knock-on: 
- Commands or queries not implementing Validate() will have to
- Commands or queries calling into the base virtual Validate() method will not compile

Rationale:
In performing mass code updates to Yumbi and Vouchers, I've seen two patterns that I'd like to get the compiler to stamp out in CQRS usage:

## 1. Calling base.Validate()
I see a lot of these calls into a virtual method that does nothing. I think it's just a habit that crept in, but it's noise within the derivative command/query classes and unnecessary (albeit very minor) overhead via virtual method calls - to essentially do nothing. If we're lucky, the compiler is stripping this out in Release mode, but I haven't checked up on this

## 2. Forgetting to Validate() when necessary
Very few commands or queries are candidates for zero validation - at the very least, validation should include checking that parameters provided for the command / query are within valid ranges (and normally do). The only time that this is unnecessary is on a "fetch-all" query (of which I've seen very few - most are test queries within Codeo.CQRS, to be honest) or an "update-all" or "blind-insert" command (which are only hypothetical - I haven't seen a use-case for either of these.

---

Basically, keeping .Validate `virtual` is probably providing more harm than good - for the rare cases where nothing is to be implemented for validation, leaving the block empty, perhaps with a comment like `nothing to validate` at least makes it clear that the author considered validation.

This doesn't affect Yumbi - yet. Eventually, it would be great to make Yumbi depend on Codeo.CQRS as part of the drive to provide standard libraries for Codeo projects. I know that making such a move for SPAR would be a lot more effort, but in case the SPAR team is perhaps interested one day in consolidating, I've included for comment, as well as the whole Yumbi team here because this particular PR becomes a point of discussion on style. As much as I believe it's the right thing to do to make this change, it's one of those things I think team consensus is important on because it (eventually) affects everyone downstream. 

My more immediate aim is to make Vouchers use this library, so at the very least, that will eventually affect any Yumbi people working on Vouchers.